### PR TITLE
NOM-51/central-storage-account-with-cdn

### DIFF
--- a/iac/devopsutils/storage_account.tf
+++ b/iac/devopsutils/storage_account.tf
@@ -18,7 +18,7 @@ resource "azurerm_cdn_profile" "central" {
   name                = "cdn${var.environment_settings.environment}profile"
 
   resource_group_name = data.azurerm_resource_group.rg.name
-  location            = var.environment_settings.region
+  location            = "northeurope"
   sku                 = "Standard_Microsoft"
 }
 

--- a/iac/devopsutils/storage_account.tf
+++ b/iac/devopsutils/storage_account.tf
@@ -15,7 +15,7 @@ resource "azurerm_storage_container" "images" {
 }
 
 resource "azurerm_cdn_profile" "central" {
-  name                = "cdn${${var.environment_settings.environment}}profile"
+  name                = "cdn${var.environment_settings.environment}profile"
 
   resource_group_name = data.azurerm_resource_group.rg.name
   location            = var.environment_settings.region

--- a/iac/devopsutils/storage_account.tf
+++ b/iac/devopsutils/storage_account.tf
@@ -1,0 +1,37 @@
+resource "azurerm_storage_account" "central" {
+  name                      = "st-${var.environment_settings.environment}-${var.environment_settings.region_code}-${var.environment_settings.app_name}"
+  resource_group_name       = data.azurerm_resource_group.rg.name
+  location                  = var.environment_settings.region
+
+  account_kind              = "StorageV2"
+  account_tier              = "Standard"
+  account_replication_type  = "LRS" 
+}
+
+resource "azurerm_storage_container" "images" {
+  name                  = "images"
+  storage_account_name  = azurerm_storage_account.central.name
+  container_access_type = "blob"
+}
+
+resource "azurerm_cdn_profile" "central" {
+  name                = "cdn${${var.environment_settings.environment}}profile"
+
+  resource_group_name = data.azurerm_resource_group.rg.name
+  location            = var.environment_settings.region
+  sku                 = "Standard_Microsoft"
+}
+
+resource "azurerm_cdn_endpoint" "central_blob" {
+  name                          = "st-${var.environment_settings.environment}-${var.environment_settings.region_code}-${var.environment_settings.app_name}"
+  profile_name                  = azurerm_cdn_profile.central.name
+  resource_group_name           = data.azurerm_resource_group.rg.name
+  location                      = var.environment_settings.region
+  origin_host_header            = azurerm_storage_account.central.primary_blob_host
+  querystring_caching_behaviour = "IgnoreQueryString"
+
+  origin {
+    name      = "storageOrigin" # An arbitrary name for the origin
+    host_name = azurerm_storage_account.central.primary_blob_host
+  }
+}

--- a/iac/devopsutils/storage_account.tf
+++ b/iac/devopsutils/storage_account.tf
@@ -26,7 +26,7 @@ resource "azurerm_cdn_endpoint" "central_blob" {
   name                          = "st-${var.environment_settings.environment}-${var.environment_settings.region_code}-${var.environment_settings.app_name}"
   profile_name                  = azurerm_cdn_profile.central.name
   resource_group_name           = data.azurerm_resource_group.rg.name
-  location                      = var.environment_settings.region
+  location                      = "northeurope"
   origin_host_header            = azurerm_storage_account.central.primary_blob_host
   querystring_caching_behaviour = "IgnoreQueryString"
 

--- a/iac/devopsutils/storage_account.tf
+++ b/iac/devopsutils/storage_account.tf
@@ -1,5 +1,5 @@
 resource "azurerm_storage_account" "central" {
-  name                      = "st-${var.environment_settings.environment}-${var.environment_settings.region_code}-${var.environment_settings.app_name}"
+  name                      = "st${var.environment_settings.environment}${var.environment_settings.region_code}${var.environment_settings.app_name}"
   resource_group_name       = data.azurerm_resource_group.rg.name
   location                  = var.environment_settings.region
 


### PR DESCRIPTION
This PR contains the following;

* Create a Storage account in devopsutils Resource Group that will be used to host all nomad entity images. 
* Created a CDN profile with an endpoint pointed at the above Storage Accounts blob service to serve our images.